### PR TITLE
Add bnd_tap support to UIBarButtonItem

### DIFF
--- a/Bond.xcodeproj/project.pbxproj
+++ b/Bond.xcodeproj/project.pbxproj
@@ -38,6 +38,8 @@
 		160FA2DF1BFD1AAB00D09C00 /* MutableObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 160FA2DD1BFD1A5E00D09C00 /* MutableObservable.swift */; };
 		160FA2E01BFD1AAC00D09C00 /* MutableObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 160FA2DD1BFD1A5E00D09C00 /* MutableObservable.swift */; };
 		160FA2E21BFD1ABE00D09C00 /* MutableObservableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 160FA2E11BFD1ABE00D09C00 /* MutableObservableTests.swift */; };
+		2C94114B1BFFB4CD0091D9CB /* UIBarButtonItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C94114A1BFFB4CD0091D9CB /* UIBarButtonItemTests.swift */; };
+		2C94114D1BFFB7F10091D9CB /* UIBarButtonItem+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C94114C1BFFB7F10091D9CB /* UIBarButtonItem+Bond.swift */; };
 		52CC7A1E1BC4C71F0010D41E /* NSAppearanceCustomization+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52CC7A1D1BC4C71F0010D41E /* NSAppearanceCustomization+Bond.swift */; };
 		52CC7A201BC4C7DC0010D41E /* NSAppearanceCustomizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52CC7A1F1BC4C7DC0010D41E /* NSAppearanceCustomizationTests.swift */; };
 		69491BB41A7C217100A13B6B /* Bond.h in Headers */ = {isa = PBXBuildFile; fileRef = 69491BB31A7C217100A13B6B /* Bond.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -222,6 +224,8 @@
 		03ACB5221AB6C840001B3E64 /* AssertEqualForOptionals.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssertEqualForOptionals.swift; sourceTree = "<group>"; };
 		160FA2DD1BFD1A5E00D09C00 /* MutableObservable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MutableObservable.swift; sourceTree = "<group>"; };
 		160FA2E11BFD1ABE00D09C00 /* MutableObservableTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MutableObservableTests.swift; sourceTree = "<group>"; };
+		2C94114A1BFFB4CD0091D9CB /* UIBarButtonItemTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIBarButtonItemTests.swift; sourceTree = "<group>"; };
+		2C94114C1BFFB7F10091D9CB /* UIBarButtonItem+Bond.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIBarButtonItem+Bond.swift"; sourceTree = "<group>"; };
 		52CC7A1D1BC4C71F0010D41E /* NSAppearanceCustomization+Bond.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSAppearanceCustomization+Bond.swift"; sourceTree = "<group>"; };
 		52CC7A1F1BC4C7DC0010D41E /* NSAppearanceCustomizationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSAppearanceCustomizationTests.swift; sourceTree = "<group>"; };
 		69491BAE1A7C217100A13B6B /* Bond.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Bond.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -584,6 +588,7 @@
 				ECAD68D81B77BB1D00837A36 /* UITextField+Bond.swift */,
 				ECAD68D91B77BB1D00837A36 /* UITextView+Bond.swift */,
 				ECAD68DA1B77BB1D00837A36 /* UIView+Bond.swift */,
+				2C94114C1BFFB7F10091D9CB /* UIBarButtonItem+Bond.swift */,
 			);
 			path = iOS;
 			sourceTree = "<group>";
@@ -640,6 +645,7 @@
 				ECAD696B1B77D43D00837A36 /* UITextFieldTests.swift */,
 				ECAD696C1B77D43D00837A36 /* UITextViewTests.swift */,
 				ECAD696D1B77D43D00837A36 /* UIViewTests.swift */,
+				2C94114A1BFFB4CD0091D9CB /* UIBarButtonItemTests.swift */,
 			);
 			name = UIKit;
 			sourceTree = "<group>";
@@ -948,6 +954,7 @@
 				EC0075DC1B90E5F400249C31 /* UITableView+Bond.swift in Sources */,
 				ECA725501BB983A0003A4ABA /* SimpleDiff.swift in Sources */,
 				EC0075B31B90D39500249C31 /* EventProducer.swift in Sources */,
+				2C94114D1BFFB7F10091D9CB /* UIBarButtonItem+Bond.swift in Sources */,
 				EC3228AA1B9F5673002BE73A /* UISegmentedControl+Bond.swift in Sources */,
 				EC0075B91B90E4DC00249C31 /* NSObject+Bond.swift in Sources */,
 				ECAD68EB1B77BB1D00837A36 /* BindableType.swift in Sources */,
@@ -1001,6 +1008,7 @@
 				ECA7254E1BB980E0003A4ABA /* ObservableArrayTests.swift in Sources */,
 				ECAD697D1B77D43D00837A36 /* UITextViewTests.swift in Sources */,
 				ECAD697B1B77D43D00837A36 /* UITableViewTests.swift in Sources */,
+				2C94114B1BFFB4CD0091D9CB /* UIBarButtonItemTests.swift in Sources */,
 				ECAD69701B77D43D00837A36 /* UIButtonTests.swift in Sources */,
 				160FA2E21BFD1ABE00D09C00 /* MutableObservableTests.swift in Sources */,
 				ECAD696E1B77D43D00837A36 /* UIActivityIndicatorTests.swift in Sources */,

--- a/Bond/Extensions/iOS/UIBarButtonItem+Bond.swift
+++ b/Bond/Extensions/iOS/UIBarButtonItem+Bond.swift
@@ -1,0 +1,77 @@
+//
+//  The MIT License (MIT)
+//
+//  Copyright (c) 2015 Srdan Rasic (@srdanrasic)
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
+import UIKit
+
+@objc class UIBarButtonItemBondHelper: NSObject
+{
+  weak var control: UIBarButtonItem?
+  var sink: Void -> Void
+  
+  init(control: UIBarButtonItem, sink: Void -> Void) {
+    self.control = control
+    self.sink = sink
+    super.init()
+    control.target = self
+    control.action = Selector("action:")
+  }
+  
+  func action(control: UIBarButtonItem) {
+    sink()
+  }
+  
+  deinit {
+    control?.target = nil
+  }
+}
+
+extension UIBarButtonItem {
+  
+  private struct AssociatedKeys {
+    static var TapKey = "bnd_TapKey"
+    static var BarButtonItemBondHelperKey = "bnd_BarButtonItemBondHelperKey"
+  }
+  
+  public var bnd_tap: EventProducer<Void> {
+    if let bnd_tap: AnyObject = objc_getAssociatedObject(self, &AssociatedKeys.TapKey) {
+      return bnd_tap as! EventProducer<Void>
+    }
+    else {
+      var capturedSink: (Void -> Void)! = nil
+      let bnd_tap = EventProducer<Void> { sink in
+        capturedSink = sink
+        return nil
+      }
+      
+      let barButtonItemHelper = UIBarButtonItemBondHelper(control: self, sink: capturedSink)
+      
+      objc_setAssociatedObject(self, &AssociatedKeys.BarButtonItemBondHelperKey, barButtonItemHelper, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+      objc_setAssociatedObject(self, &AssociatedKeys.TapKey, bnd_tap, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+      return bnd_tap
+    }
+  }
+}
+
+
+

--- a/BondTests/UIBarButtonItemTests.swift
+++ b/BondTests/UIBarButtonItemTests.swift
@@ -1,0 +1,30 @@
+//
+//  UIBarButtonItemTests.swift
+//  Bond
+//
+//  Created by Ivan Sergeyenko on 2015-11-20.
+//  Copyright © 2015 Bond. All rights reserved.
+//
+
+import UIKit
+import XCTest
+@testable import Bond
+
+
+class UIBarButtonItemTests: XCTestCase {
+  
+  func testUIBarButtonItemObservable() {
+    let button = UIBarButtonItem()
+    var tapObserved = false
+
+    button.bnd_tap.observe {
+      tapObserved = true
+    }
+
+    XCTAssert(tapObserved == false, "Value after binding should not be changed")
+
+    UIApplication.sharedApplication().sendAction(button.action, to: button.target, from: nil, forEvent: nil)
+
+    XCTAssert(tapObserved == true, "Should update value after action is fired")
+  }
+}


### PR DESCRIPTION
`UIBarButtonItem` is not a `UIControl` and hence didn't have a convenient `btn_tap` extension - until now.
