### PR TITLE
changed bnd_selected return type from Observable<Bool> to EventProduc…

### DIFF
--- a/Bond/Extensions/iOS/UIButton+Bond.swift
+++ b/Bond/Extensions/iOS/UIButton+Bond.swift
@@ -36,8 +36,8 @@ extension UIButton {
     return self.bnd_controlEvent.filter { $0 == UIControlEvents.TouchUpInside }.map { e in }
   }
   
-  public var bnd_selected: Observable<Bool> {
-    return bnd_associatedObservableForValueForKey("selected")
+  public var bnd_selected: EventProducer<Bool> {
+    return self.bnd_controlEvent.filter { $0 == UIControlEvents.TouchUpInside }.map { _ in self.selected }
   }
   
   public var bnd_highlighted: Observable<Bool> {


### PR DESCRIPTION
Can't observe selected status of UIButton.
Please check below example and merge request.

``` swift
@IBOutlet var testButton: UIButton!

@IBAction func touchedTestButton(sender: UIButton) {
    testButton.selected = !sender.selected
}

testButton.bnd_selected.observe { _ in
    // not working
}
```
