### PR TITLE
Remove datasource from collectionView on BNDCollectionViewDataSource …

### DIFF
--- a/Bond/Core/Disposable.swift
+++ b/Bond/Core/Disposable.swift
@@ -147,6 +147,11 @@ public final class DisposeBag: DisposableType {
     disposables.append(disposable)
   }
   
+  /// Adds the given disposables to the bag.
+  public func put(array:[ DisposableType ]) {
+    disposables.appendContentsOf(array)
+  }
+  
   /// Disposes all disposables that are currenty in the bag.
   public func dispose() {
     for disposable in disposables {

--- a/Bond/Extensions/iOS/UICollectionView+Bond.swift
+++ b/Bond/Extensions/iOS/UICollectionView+Bond.swift
@@ -76,6 +76,10 @@ private class BNDCollectionViewDataSource<T>: NSObject, UICollectionViewDataSour
     }.disposeIn(bnd_bag)
   }
   
+  deinit {
+    collectionView.dataSource = nil
+  }
+  
   private func setupPerSectionObservers() {
     sectionObservingDisposeBag.dispose()
     


### PR DESCRIPTION
Hi, 
we had some problem with crash in our application

_[_TtGC4BondP33_9102B403720A1FA7EF4238F1B745828427BNDCollectionViewDataSourceP17CCRestIntegration19CCViewModelProtocol_ numberOfSectionsInCollectionView:]: message sent to deallocated instance_

So we handle solution with this pull request. Hope you will find it useful 
