### PR TITLE
Fix access level for replace(with:)

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "ReactiveKit/ReactiveKit" "v3.0.0-beta4"
+github "ReactiveKit/ReactiveKit" "v3.0.0-beta5"

--- a/Sources/ObservableArray.swift
+++ b/Sources/ObservableArray.swift
@@ -40,7 +40,7 @@ public protocol ObservableArrayEventProtocol {
   var source: ObservableArray<Item> { get }
 }
 
-public struct ObservableArrayEvent<Item> {
+public struct ObservableArrayEvent<Item>: ObservableArrayEventProtocol {
   public let change: ObservableArrayChange
   public let source: ObservableArray<Item>
 }
@@ -300,7 +300,7 @@ extension Array where Element: Equatable {
 
 extension MutableObservableArray {
   
-  func replace(with array: [Item]) {
+  public func replace(with array: [Item]) {
     lock.atomic {
       self.array = array
       subject.next(ObservableArrayEvent(change: .reset, source: self))


### PR DESCRIPTION
replace(with:) should be public.