### PR TITLE
Fix inconsistent nullability in ProtocolProxy

### DIFF
--- a/Bond/ProtocolProxy.swift
+++ b/Bond/ProtocolProxy.swift
@@ -26,9 +26,12 @@ import Foundation
 import ObjectiveC
 import ReactiveKit
 
+public typealias ArgumentExtractor = (Int, UnsafeMutableRawPointer?) -> Void
+public typealias ReturnValueSetter = (UnsafeMutableRawPointer?) -> Void
+
 public class ProtocolProxy: RKProtocolProxyBase {
 
-  private var invokers: [Selector: ((Int, UnsafeMutableRawPointer) -> Void, ((UnsafeMutableRawPointer) -> Void)?) -> Void] = [:]
+  private var invokers: [Selector: (ArgumentExtractor, ReturnValueSetter?) -> Void] = [:]
   private var handlers: [Selector: AnyObject] = [:]
   private weak var object: NSObject?
   private let setter: Selector
@@ -53,7 +56,7 @@ public class ProtocolProxy: RKProtocolProxyBase {
     return invokers[selector] != nil
   }
 
-  public override func invoke(with selector: Selector, argumentExtractor: @escaping (Int, UnsafeMutableRawPointer?) -> Void, setReturnValue: ((UnsafeMutableRawPointer?) -> Void)?) {
+  public override func invoke(with selector: Selector, argumentExtractor: @escaping ArgumentExtractor, setReturnValue: ReturnValueSetter?) {
     guard let invoker = invokers[selector] else { return }
     invoker(argumentExtractor, setReturnValue)
   }

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "ReactiveKit/ReactiveKit" "v3.0.0-beta5"
+github "ReactiveKit/ReactiveKit" "v3.0.0-beta6"

--- a/Sources/NSObject.swift
+++ b/Sources/NSObject.swift
@@ -56,8 +56,8 @@ extension NSObject: Deallocatable {
   
   /// Use this bag to dispose disposables upon the deallocation of the receiver.
   public var bnd_bag: DisposeBag {
-    if let disposeBag = objc_getAssociatedObject(self, &AssociatedKeys.DisposeBagKey) {
-      return disposeBag as! DisposeBag
+    if let disposeBag = objc_getAssociatedObject(self, &AssociatedKeys.DisposeBagKey) as? DisposeBag {
+      return disposeBag
     } else {
       let disposeBag = DisposeBag()
       objc_setAssociatedObject(self, &AssociatedKeys.DisposeBagKey, disposeBag, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC)


### PR DESCRIPTION
In ProtocolProxy,

`invokers` has `UnsafeMutableRawPointer`,
while `invoke` calls this invokers with `UnsafeMutableRawPointer?`.

As swift 3 disallow assigning `nil` to `UnsafeMutableRawPointer`,
changed `invokers` to have `?`.