### PR TITLE
Fix function visibility for ObservableDictionary/ObservableSet.replace()

### DIFF
--- a/Sources/ObservableDictionary.swift
+++ b/Sources/ObservableDictionary.swift
@@ -134,7 +134,7 @@ public class MutableObservableDictionary<Key: Hashable, Value>: ObservableDictio
     }
   }
 
-  func replace(with dictionary: Dictionary<Key, Value>) {
+  public func replace(with dictionary: Dictionary<Key, Value>) {
     lock.atomic {
       self.dictionary = dictionary
       subject.next(ObservableDictionaryEvent(kind: .reset, source: self))

--- a/Sources/ObservableSet.swift
+++ b/Sources/ObservableSet.swift
@@ -133,7 +133,7 @@ public class MutableObservableSet<Element: Hashable>: ObservableSet<Element> {
     }
   }
 
-  func replace(with set: Set<Element>) {
+  public func replace(with set: Set<Element>) {
     lock.atomic {
       self.set = set
       subject.next(ObservableSetEvent(kind: .reset, source: self))


### PR DESCRIPTION
Noticed newly introduced replace() functions for ObservableDictionary/ObservableSet aren't set to `public`, causing them to be unusable from outside of the framework.