### PR TITLE
Rename RKProtocolProxyBase to BNDProtocolProxyBase

### DIFF
--- a/Bond/BNDProtocolProxyBase.h
+++ b/Bond/BNDProtocolProxyBase.h
@@ -24,7 +24,7 @@
 
 #import <Foundation/Foundation.h>
 
-@interface RKProtocolProxyBase : NSObject
+@interface BNDProtocolProxyBase : NSObject
 
 @property (nonatomic, readonly, nonnull, strong) Protocol *protocol;
 

--- a/Bond/BNDProtocolProxyBase.m
+++ b/Bond/BNDProtocolProxyBase.m
@@ -25,11 +25,11 @@
 #import "BNDProtocolProxyBase.h"
 #import <objc/runtime.h>
 
-@interface RKProtocolProxyBase ()
+@interface BNDProtocolProxyBase ()
 @property (nonatomic, readwrite, strong) Protocol *protocol;
 @end
 
-@implementation RKProtocolProxyBase
+@implementation BNDProtocolProxyBase
 
 - (instancetype)initWithProtocol:(Protocol *)protocol
 {

--- a/Bond/ProtocolProxy.swift
+++ b/Bond/ProtocolProxy.swift
@@ -26,7 +26,7 @@ import Foundation
 import ObjectiveC
 import ReactiveKit
 
-public class ProtocolProxy: RKProtocolProxyBase {
+public class ProtocolProxy: BNDProtocolProxyBase {
 
   private var invokers: [Selector: ((Int, UnsafeMutableRawPointer) -> Void, ((UnsafeMutableRawPointer) -> Void)?) -> Void] = [:]
   private var handlers: [Selector: AnyObject] = [:]

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "ReactiveKit/ReactiveKit" "v3.0.0-beta5"
+github "ReactiveKit/ReactiveKit" "v3.0.0-beta6"


### PR DESCRIPTION
BNDProtocolProxyBase.h, .m has a class `RKProtocolProxyBase`.

Make class name consistent with filename and framework prefix `BND`.

