### PR TITLE
DynamicSubject bidirectionalMap

### DIFF
--- a/Sources/DynamicSubject.swift
+++ b/Sources/DynamicSubject.swift
@@ -93,4 +93,18 @@ public struct DynamicSubject<Target: Deallocatable, Element>: SubjectProtocol, B
       return nil
     }
   }
+  
+  /// Transform the `getter` and `setter` by applying a `transform` on them.
+  public func bidirectionalMap<U>(_ getTransform: @escaping (Element) -> U,
+                               _ setTransform: @escaping (U) -> Element) -> DynamicSubject<Target, U>! {
+    guard let target = target else { return nil }
+    return DynamicSubject<Target, U>(target: target,
+                                     signal: signal,
+                                     get: { [getter] (target) -> U in
+                                      return getTransform(getter(target))
+      },
+                                     set: { [setter] (target, element) in
+                                      setter(target, setTransform(element))
+      })
+  }
 }

--- a/Sources/DynamicSubject.swift
+++ b/Sources/DynamicSubject.swift
@@ -95,9 +95,10 @@ public struct DynamicSubject<Target: Deallocatable, Element>: SubjectProtocol, B
   }
   
   /// Transform the `getter` and `setter` by applying a `transform` on them.
-  public func bidirectionalMap<U>(_ getTransform: @escaping (Element) -> U,
-                               _ setTransform: @escaping (U) -> Element) -> DynamicSubject<Target, U>! {
+  public func bidirectionalMap<U>(to getTransform: @escaping (Element) -> U,
+                               from setTransform: @escaping (U) -> Element) -> DynamicSubject<Target, U>! {
     guard let target = target else { return nil }
+    
     return DynamicSubject<Target, U>(target: target,
                                      signal: signal,
                                      get: { [getter] (target) -> U in


### PR DESCRIPTION
This function allows a `DynamicSubject` to be transformed to a new `DynamicSubject` using closures to transform the subject's `Element` in both directions.

Example:

````swift
let subject: DynamicSubject<NSObject, String?> = object
            .dynamic(keyPath: "numberProperty", ofType: NSNumber?)
            .bidirectionalMap(to: { $0?.stringValue },
                              from: { NSNumber(integer: Int($0)) })
````
