### PR TITLE
Added 'dynamic(keyPath:)' method without 'ofType' parameter.

### DIFF
--- a/Sources/NSObject+KVO.swift
+++ b/Sources/NSObject+KVO.swift
@@ -35,6 +35,10 @@ public extension NSObject {
       set: { $0.setValue($1, forKeyPath: keyPath) }
     )
   }
+  
+  public func dynamic<T>(keyPath: String) -> DynamicSubject<NSObject, T> {
+    return dynamic(keyPath: keyPath, ofType: T.self)
+  }
 
   public func dynamic<T>(keyPath: String, ofType: T.Type) -> DynamicSubject<NSObject, T> where T: OptionalProtocol {
     return DynamicSubject(
@@ -50,6 +54,11 @@ public extension NSObject {
       }
     )
   }
+  
+  public func dynamic<T>(keyPath: String) -> DynamicSubject<NSObject, T> where T: OptionalProtocol {
+    return dynamic(keyPath: keyPath, ofType: T.self)
+  }
+  
 }
 
 // MARK: - Implementation


### PR DESCRIPTION
This adds in methods for using `dynamic(keyPath:)` without needing to specify the type of `<T>` explicitly.

When `T` can be inferred, these methods can be used, and when it cannot, you can still use `dynamic(keyPath: ofType:)`.
