### PR TITLE
MutableObservableSet add update, removeAll, and indices. 

### DIFF
--- a/Bond.xcodeproj/project.pbxproj
+++ b/Bond.xcodeproj/project.pbxproj
@@ -67,6 +67,7 @@
 		16D30F091D65D82D00C2435D /* NSAppearanceCustomization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16D30F081D65D82C00C2435D /* NSAppearanceCustomization.swift */; };
 		16D30F0B1D65E8C700C2435D /* NSTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16D30F0A1D65E8C700C2435D /* NSTableView.swift */; };
 		227DEF051DCB87BF00213852 /* UIGestureRecognizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 227DEF041DCB87BF00213852 /* UIGestureRecognizer.swift */; };
+		3B8EAA5C1E205B0F00C7D06F /* ObservableSetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B8EAA5B1E205B0F00C7D06F /* ObservableSetTests.swift */; };
 		90A3FACD1E0C8D9A0086A7F1 /* Diff.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 90A3FAC81E0C8D8B0086A7F1 /* Diff.framework */; };
 		90A3FACE1E0C8D9F0086A7F1 /* Diff.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 90A3FAC81E0C8D8B0086A7F1 /* Diff.framework */; };
 		90A3FACF1E0C8DA20086A7F1 /* Diff.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 90A3FAC81E0C8D8B0086A7F1 /* Diff.framework */; };
@@ -276,6 +277,7 @@
 		16D30F081D65D82C00C2435D /* NSAppearanceCustomization.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSAppearanceCustomization.swift; sourceTree = "<group>"; };
 		16D30F0A1D65E8C700C2435D /* NSTableView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSTableView.swift; sourceTree = "<group>"; };
 		227DEF041DCB87BF00213852 /* UIGestureRecognizer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIGestureRecognizer.swift; sourceTree = "<group>"; };
+		3B8EAA5B1E205B0F00C7D06F /* ObservableSetTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ObservableSetTests.swift; sourceTree = "<group>"; };
 		90A3FAC21E0C8D8B0086A7F1 /* Diff.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Diff.xcodeproj; path = Carthage/Checkouts/Diff.swift/Diff.xcodeproj; sourceTree = "<group>"; };
 		EC06A8751DBCB147006AEA81 /* NSObjectTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSObjectTests.swift; sourceTree = "<group>"; };
 		EC2505B01D3F570500A6E14A /* UILabel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UILabel.swift; path = Sources/UIKit/UILabel.swift; sourceTree = SOURCE_ROOT; };
@@ -431,6 +433,7 @@
 				ECCF8A571D9007AF00575DA8 /* BondTests.swift */,
 				ECD594091D93EC9700C840C2 /* DynamicSubjectTests.swift */,
 				ECCF8A511D8FFEF300575DA8 /* ObservableArrayTests.swift */,
+				3B8EAA5B1E205B0F00C7D06F /* ObservableSetTests.swift */,
 				16887E2F1D74499A00EDA099 /* ProtocolProxyTests.swift */,
 				16210A4A1D3EC474004AEDF3 /* UIKitTests.swift */,
 				EC96935A1D943B15004EB5EE /* UITableViewTests.swift */,
@@ -902,6 +905,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				ECCF8A521D8FFEF300575DA8 /* ObservableArrayTests.swift in Sources */,
+				3B8EAA5C1E205B0F00C7D06F /* ObservableSetTests.swift in Sources */,
 				16887E301D74499A00EDA099 /* ProtocolProxyTests.swift in Sources */,
 				ECD5940A1D93EC9700C840C2 /* DynamicSubjectTests.swift in Sources */,
 				EC06A8761DBCB147006AEA81 /* NSObjectTests.swift in Sources */,

--- a/BondTests/ObservableSetTests.swift
+++ b/BondTests/ObservableSetTests.swift
@@ -1,0 +1,84 @@
+//
+//  ObservableSetTests.swift
+//  Bond
+//
+//  Created by Ahmed Afifi on 19/09/16.
+//  Copyright © 2016 Swift Bond. All rights reserved.
+//
+
+import XCTest
+@testable import Bond
+
+class ObservableSetTests: XCTestCase {
+
+  var set: MutableObservableSet<IntBox>!
+
+  struct IntBox: Hashable {
+    let identifier: Int
+    let contents: String
+
+    var hashValue: Int {
+      return identifier.hashValue
+    }
+
+    static func ==(lhs: IntBox, rhs: IntBox) -> Bool {
+      return lhs.identifier == rhs.identifier
+    }
+  }
+
+  override func setUp() {
+    super.setUp()
+    let itemOne = IntBox(identifier: 1, contents: "Item One")
+    let itemTwo = IntBox(identifier: 2, contents: "Item Two")
+    let itemThree = IntBox(identifier: 3, contents: "Item Three")
+
+    set = MutableObservableSet([itemOne, itemTwo, itemThree])
+  }
+
+  func testRemoveAll() {
+    set.removeAll()
+    XCTAssert(set.isEmpty)
+  }
+
+  func testInsertOfExistingItem() {
+    let updatedItemOne = IntBox(identifier: 1, contents: "New Item One")
+
+    // Expect no updates due to already existing element
+
+    set.insert(updatedItemOne)
+
+    let index = set.index(of: updatedItemOne)!
+    XCTAssert(set[index] == updatedItemOne)
+    XCTAssert(set[index].contents == "Item One")
+  }
+
+  func testInsertNewItem() {
+    let newItem = IntBox(identifier: 4, contents: "Item Four")
+
+    set.insert(newItem)
+
+    let index = set.index(of: newItem)!
+    XCTAssert(set[index] == newItem)
+    XCTAssert(set[index].contents == "Item Four")
+  }
+
+  func testUpdateExistingItem() {
+    let updatedItemOne = IntBox(identifier: 1, contents: "New Item One")
+
+    set.update(updatedItemOne)
+
+    let index = set.index(of: updatedItemOne)!
+    XCTAssert(set[index] == updatedItemOne)
+    XCTAssert(set[index].contents == "New Item One")
+  }
+
+  func testUpdateNewItem() {
+    let newItem = IntBox(identifier: 4, contents: "Item Four")
+
+    set.update(newItem)
+
+    let index = set.index(of: newItem)!
+    XCTAssert(set[index] == newItem)
+    XCTAssert(set[index].contents == "Item Four")
+  }
+}

--- a/Sources/Collections/ObservableSet.swift
+++ b/Sources/Collections/ObservableSet.swift
@@ -153,6 +153,15 @@ public class MutableObservableSet<Element: Hashable>: ObservableSet<Element> {
     }
   }
 
+  /// Remove item from the set by index.
+  @discardableResult
+  public func remove(at index: SetIndex<Element>) -> Element? {
+    lock.lock(); defer { lock.unlock() }
+    let element = set.remove(at: index)
+    subject.next(ObservableSetEvent(kind: .deletes([index]), source: self))
+    return element
+  }
+
   /// Removes all items from the set.
   public func removeAll() {
     lock.lock(); defer { lock.unlock() }


### PR DESCRIPTION
Noticed that the MutableObservableSet class acted as though inserting a duplicate item updated the Set. There is a method `update(with:)` which always inserts duplicates. Added some tests to demonstrate what I mean.

Also added a removeAll() method like MutableObservableArray has.

I ran into some issues adding tests around expecting ObservableSet updates. I can finish that up with some advisement.