### PR TITLE
Updated to use ReactiveExtensions in ProtocolProxy example

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,12 +224,12 @@ then the image processing will be automatically cancelled when the image view ge
 
 Bond provides NSObject extensions that makes it easy to convert delegate pattern into signals.
 
-First make an extension on your type, UITableView in the following example, that provides a reactive delegate proxy:
+First make an extension on ReactiveExtensions (where `Base` is defined as your type - `UITableView` in the following example), that provides a reactive delegate proxy:
 
 ```swift
-extension UITableView {
-  public delegate: ProtocolProxy {
-    return protocolProxy(for: UITableViewDelegate.self, setter: NSSelectorFromString("setDelegate:"))
+extension ReactiveExtensions where Base: UITableView {
+  public var delegate: ProtocolProxy {
+    return base.protocolProxy(for: UITableViewDelegate.self, setter: NSSelectorFromString("setDelegate:"))
   }
 }
 ```


### PR DESCRIPTION
`public delegate: ProtocolProxy` was missing `var`, so I fixed that - but also thought it would be good to show the actual `extension ReactiveExtensions` usage as it fits in with the example that's given further down