### PR TITLE
Change NSControl.reactive.controlEvent to emit the sender, rather than objectValue

### DIFF
--- a/Sources/AppKit/NSButton.swift
+++ b/Sources/AppKit/NSButton.swift
@@ -27,6 +27,14 @@ import ReactiveKit
 
 public extension ReactiveExtensions where Base: NSButton {
 
+  public var state: DynamicSubject<Int> {
+    return dynamicSubject(
+      signal: controlEvent.eraseType(),
+      get: { $0.state },
+      set: { $0.state = $1 }
+    )
+  }
+
   public var title: Bond<String> {
     return bond { $0.title = $1 }
   }
@@ -41,10 +49,6 @@ public extension ReactiveExtensions where Base: NSButton {
 
   public var alternateImage: Bond<NSImage?> {
       return bond { $0.alternateImage = $1 }
-  }
-
-  public var state: Bond<Int> {
-    return bond { $0.state = $1 }
   }
 
   public var imagePosition: Bond<NSCellImagePosition> {

--- a/Sources/AppKit/NSColorWell.swift
+++ b/Sources/AppKit/NSColorWell.swift
@@ -27,8 +27,13 @@ import ReactiveKit
 
 public extension ReactiveExtensions where Base: NSColorWell {
 
-  public var color: Bond<NSColor> {
-    return bond { $0.color = $1 }
+  public var color: DynamicSubject<NSColor> {
+    return dynamicSubject(
+      signal: keyPath(#keyPath(NSColorWell.color), ofType: NSColor.self).eraseType(),
+      triggerEventOnSetting: false,
+      get: { $0.color },
+      set: { $0.color = $1 }
+    )
   }
 
   public var isBordered: Bond<Bool> {

--- a/Sources/AppKit/NSControl.swift
+++ b/Sources/AppKit/NSControl.swift
@@ -68,6 +68,10 @@ public extension ReactiveExtensions where Base: NSControl {
     }
   }
 
+  public func controlEvent<T>(_ read: @escaping (Base) -> T) -> SafeSignal<T> {
+    return controlEvent.map(read)
+  }
+
   public var isEnabled: Bond<Bool> {
     return bond { $0.isEnabled = $1 }
   }

--- a/Sources/AppKit/NSControl.swift
+++ b/Sources/AppKit/NSControl.swift
@@ -45,7 +45,7 @@ fileprivate extension NSControl {
     }
 
     func eventHandler(_ sender: NSControl?) {
-      subject.next(sender!.objectValue as AnyObject?)
+      subject.next(sender)
     }
 
     deinit {
@@ -58,13 +58,13 @@ fileprivate extension NSControl {
 
 public extension ReactiveExtensions where Base: NSControl {
 
-  public var controlEvent: SafeSignal<AnyObject?> {
+  public var controlEvent: SafeSignal<Base> {
     if let controlHelper = objc_getAssociatedObject(base, &NSControl.AssociatedKeys.ControlHelperKey) as AnyObject? {
-      return (controlHelper as! NSControl.BondHelper).subject.toSignal()
+      return (controlHelper as! NSControl.BondHelper).subject.map { $0 as! Base }.toSignal()
     } else {
       let controlHelper = NSControl.BondHelper(control: base)
       objc_setAssociatedObject(base, &NSControl.AssociatedKeys.ControlHelperKey, controlHelper, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC)
-      return controlHelper.subject.toSignal()
+      return controlHelper.subject.map { $0 as! Base }.toSignal()
     }
   }
 


### PR DESCRIPTION
I'm a little torn on this change, but I think it would be better if `NSControl.reactive.controlEvent` emitted the sending control (`sender`), rather than casting the `objectValue` property to `AnyObject?`. 

Not all AppKit controls emit useful or meaningful control state information via `objectValue` (`NSPopUpButton` being one example). 

With this change, the developer can choose what they want to interrogate from the sending control. 

Thoughts?