### PR TITLE
Fix KVODeallocate crash with NSColorWell’s color property

### DIFF
--- a/Sources/AppKit/NSColorWell.swift
+++ b/Sources/AppKit/NSColorWell.swift
@@ -29,7 +29,7 @@ public extension ReactiveExtensions where Base: NSColorWell {
 
   public var color: DynamicSubject<NSColor> {
     return dynamicSubject(
-      signal: keyPath(#keyPath(NSColorWell.color), ofType: NSColor.self).eraseType(),
+      signal: controlEvent.eraseType(),
       triggerEventOnSetting: false,
       get: { $0.color },
       set: { $0.color = $1 }


### PR DESCRIPTION
It seems like there are underlying issues with Key-Value Observing `NSColorWell.color`, so I've switched this to use the `controlEvent` instead. Works 👍 