### PR TITLE
Expose NSPopUpButton’s reactive extensions as DynamicSubjects

### DIFF
--- a/Sources/AppKit/NSPopUpButton.swift
+++ b/Sources/AppKit/NSPopUpButton.swift
@@ -27,20 +27,36 @@ import ReactiveKit
 
 public extension ReactiveExtensions where Base: NSPopUpButton {
 
-  public var selectedItem: Bond<NSMenuItem?> {
-    return bond { $0.select($1) }
+  public var selectedItem: DynamicSubject<NSMenuItem?> {
+    return dynamicSubject(
+      signal: controlEvent.eraseType(),
+      get: { $0.selectedItem },
+      set: { $0.select($1) }
+    )
   }
 
-  public var selectedItemAtIndex: Bond<Int> {
-    return bond { $0.selectItem(at: $1) }
+  public var indexOfSelectedItem: DynamicSubject<Int?> {
+    return dynamicSubject(
+      signal: controlEvent.eraseType(),
+      get: { $0.indexOfSelectedItem },
+      set: { $0.selectItem(at: $1 ?? -1) }
+    )
   }
 
-  public var selectedItemWithTitle: Bond<String> {
-    return bond { $0.selectItem(withTitle: $1) }
+  public var titleOfSelectedItem: DynamicSubject<String?> {
+    return dynamicSubject(
+      signal: controlEvent.eraseType(),
+      get: { $0.titleOfSelectedItem },
+      set: { $0.selectItem(withTitle: $1 ?? "") }
+    )
   }
 
-  public var selectedItemWithTag: Bond<Int> {
-    return bond { $0.selectItem(withTag: $1) }
+  public var tagOfSelectedItem: DynamicSubject<Int?> {
+    return dynamicSubject(
+      signal: controlEvent.eraseType(),
+      get: { $0.selectedItem?.tag },
+      set: { $0.selectItem(withTag: $1 ?? -1) }
+    )
   }
 }
 


### PR DESCRIPTION
I've given this a lot of thought, and I'm still quite torn. I have found that having `selectedItem` and it's cohorts exposed as `DynamicSubject<T>` is really useful. There's an argument to be made that the title and tag variants shouldn't be included, as they can be mapped from the plain `selectedItem`, however setting these values becomes quite complex, so I've included them as a convenience.

I think that in this instance, the `selectedItem` property is more akin to NSTextView's `string` property than something purely settable, as I'll often want to pass the selection back the view model. 

I'd be really happy to discuss this further. I'm trying to formulate some simple guidelines for when it's appropriate to have a two-way binding so that I don't keen going back and forth on items like this.