### PR TITLE
`NSTableView` binding improvements

### DIFF
--- a/Sources/AppKit/NSTableView.swift
+++ b/Sources/AppKit/NSTableView.swift
@@ -72,11 +72,11 @@ public protocol TableViewBond: TableViewBondOptionable {
 extension TableViewBond {
 	
 	public var insertAnimation: NSTableViewAnimationOptions? {
-		return nil
+		return [.effectFade, .slideUp]
 	}
 	
 	public var deleteAnimation: NSTableViewAnimationOptions? {
-		return nil
+		return [.effectFade, .slideUp]
 	}
 	
 	public func heightForRow(at index: Int, tableView: NSTableView, dataSource: DataSource) -> CGFloat? {
@@ -143,16 +143,6 @@ private struct DefaultTableViewBond<DataSource: DataSourceProtocol>: TableViewBo
 	
 	let createCell: (DataSource, Int, NSTableView) -> NSView?
 	
-	var animations: NSTableViewAnimationOptions
-	
-	var insertAnimation: NSTableViewAnimationOptions? {
-		return animations
-	}
-	
-	var deleteAnimation: NSTableViewAnimationOptions? {
-		return animations
-	}
-	
 	func cellForRow(at index: Int, tableView: NSTableView, dataSource: DataSource) -> NSView? {
 		return createCell(dataSource, index, tableView)
 	}
@@ -180,7 +170,7 @@ public extension SignalProtocol where Element: DataSourceEventProtocol, Element.
 	@discardableResult
 	public func bind(to tableView: NSTableView, animated: Bool = true, createCell: @escaping (DataSource, Int, NSTableView) -> NSView?) -> Disposable {
 		if animated {
-			return bind(to: tableView, using: DefaultTableViewBond<DataSource>(createCell: createCell, animations: [.effectFade, .slideUp]))
+			return bind(to: tableView, using: DefaultTableViewBond<DataSource>(createCell: createCell))
 		} else {
 			return bind(to: tableView, using: ReloadingTableViewBond<DataSource>(createCell: createCell))
 		}

--- a/Sources/AppKit/NSTableView.swift
+++ b/Sources/AppKit/NSTableView.swift
@@ -41,10 +41,18 @@ public extension SignalProtocol where Element: DataSourceEventProtocol, Element.
   public typealias DataSource = Element.DataSource
 
   @discardableResult
-  public func bind(to tableView: NSTableView, animated: Bool = true, createCell: @escaping (DataSource, Int, NSTableView) -> NSView?) -> Disposable {
+  public func bind(to tableView: NSTableView, animated: Bool = true, measureCell: ((DataSource, Int, NSTableView) -> CGFloat)? = nil, createCell: @escaping (DataSource, Int, NSTableView) -> NSView?) -> Disposable {
 
     let dataSource = Property<DataSource?>(nil)
 
+		if let measureCell = measureCell {
+      tableView.reactive.delegate.feed(
+				property: dataSource,
+				to: #selector(NSTableViewDelegate.tableView(_:heightOfRow:)),
+				map: { (dataSource: DataSource?, tableView: NSTableView, row: Int) -> CGFloat in measureCell(dataSource!, row, tableView) }
+      )
+		}
+		
     tableView.reactive.delegate.feed(
       property: dataSource,
       to: #selector(NSTableViewDelegate.tableView(_:viewFor:row:)),

--- a/Sources/AppKit/NSTableView.swift
+++ b/Sources/AppKit/NSTableView.swift
@@ -102,7 +102,7 @@ public extension SignalProtocol where Element: DataSourceEventProtocol, Element.
           defer { tableView.endUpdates() }
         }
         indexPaths.forEach { indexPath in
-          tableView.insertRows(at: IndexSet(integer: indexPath.item), withAnimation: [])
+          tableView.insertRows(at: IndexSet(integer: indexPath.item), withAnimation: [.effectFade, .slideUp])
         }
       case .deleteItems(let indexPaths):
         if !updating && indexPaths.count > 1 {
@@ -110,7 +110,7 @@ public extension SignalProtocol where Element: DataSourceEventProtocol, Element.
           defer { tableView.endUpdates() }
         }
         indexPaths.forEach { indexPath in
-          tableView.removeRows(at: IndexSet(integer: indexPath.item), withAnimation: [])
+          tableView.removeRows(at: IndexSet(integer: indexPath.item), withAnimation: [.effectFade, .slideUp])
         }
       case .reloadItems(let indexPaths):
         if !updating && indexPaths.count > 1 {
@@ -118,8 +118,8 @@ public extension SignalProtocol where Element: DataSourceEventProtocol, Element.
           defer { tableView.endUpdates() }
         }
         indexPaths.forEach { indexPath in
-          tableView.removeRows(at: IndexSet(integer: indexPath.item), withAnimation: [])
-          tableView.insertRows(at: IndexSet(integer: indexPath.item), withAnimation: [])
+          tableView.removeRows(at: IndexSet(integer: indexPath.item), withAnimation: [.effectFade, .slideUp])
+          tableView.insertRows(at: IndexSet(integer: indexPath.item), withAnimation: [.effectFade, .slideUp])
         }
       case .moveItem(let indexPath, let newIndexPath):
         tableView.moveRow(at: indexPath.item, to: newIndexPath.item)


### PR DESCRIPTION
This adds the following:

1. Ability to provide cell height measurement.
2. Ability to chose insert and delete row animations.

### Note 1

To support additional parameters without making existing bind function too messy, I decided to introduce configuration protocol that handles all configuration and refactored existing function into using internal implementation. Besides keeping API simpler, this also brings lots of flexibility and separation on API client side. The downside is use of `Any` in measure and create cell closures - couldn't find a way to reuse existing type from bind function and using associated type also didn't play nicely... The workaround would be to remove configurator protocol and/or have function that actually takes all of the parameters (with default values so it would be as simple or as complex as needed for any usecase).

### Note 2

With this implementation `animated` property in configuration protocol feels obsolete - it could be replaced by checking if both, insert and delete animations are present and assume animations in this case and no animations otherwise.

### Note 3

Additionally: existing function (without configuration protocol) should use some default animations when setting up default configurator if `animated == true`; current implementation doesn't animate in this case so there's no point in using insert/delete functions on table view - `reloadData` will work just the same. But didn't want to alter existing implementation so left it as it was.

- - -

Not sure to what extent any of this functionality is wanted in this project. Both, animations and dynamic cell height handling are prerequisites for me, however if anything feels too much, let me know and I can refactor. Or ignore this PR alltogether - I can implement all of above as extension in my own app if you feel it's too narrow in scope for general use... :)