### PR TITLE
Makes the Diff.swift framework an explicit dependency

### DIFF
--- a/Bond.xcodeproj/project.pbxproj
+++ b/Bond.xcodeproj/project.pbxproj
@@ -226,6 +226,27 @@
 			remoteGlobalIDString = 16887E361D744ABB00EDA099;
 			remoteInfo = "Bond-App";
 		};
+		9077A6751E54931D004FABE8 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 90A3FAC21E0C8D8B0086A7F1 /* Diff.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = C9EE87151CCFCA83006BD90E;
+			remoteInfo = Diff;
+		};
+		9077A67B1E549321004FABE8 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 90A3FAC21E0C8D8B0086A7F1 /* Diff.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = C9EE87151CCFCA83006BD90E;
+			remoteInfo = Diff;
+		};
+		9077A67D1E549324004FABE8 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 90A3FAC21E0C8D8B0086A7F1 /* Diff.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = C9EE87151CCFCA83006BD90E;
+			remoteInfo = Diff;
+		};
 		90A3FAC71E0C8D8B0086A7F1 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 90A3FAC21E0C8D8B0086A7F1 /* Diff.xcodeproj */;
@@ -609,6 +630,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				9077A6761E54931D004FABE8 /* PBXTargetDependency */,
 				165217951D70593600C9FAEE /* PBXTargetDependency */,
 			);
 			name = "Bond-iOS";
@@ -665,6 +687,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				9077A67C1E549321004FABE8 /* PBXTargetDependency */,
 				165217981D70594900C9FAEE /* PBXTargetDependency */,
 			);
 			name = "Bond-macOS";
@@ -684,6 +707,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				9077A67E1E549324004FABE8 /* PBXTargetDependency */,
 				1652179B1D70595300C9FAEE /* PBXTargetDependency */,
 			);
 			name = "Bond-tvOS";
@@ -1041,6 +1065,21 @@
 			isa = PBXTargetDependency;
 			target = 16887E361D744ABB00EDA099 /* Bond-App */;
 			targetProxy = 16887E491D744B2900EDA099 /* PBXContainerItemProxy */;
+		};
+		9077A6761E54931D004FABE8 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Diff;
+			targetProxy = 9077A6751E54931D004FABE8 /* PBXContainerItemProxy */;
+		};
+		9077A67C1E549321004FABE8 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Diff;
+			targetProxy = 9077A67B1E549321004FABE8 /* PBXContainerItemProxy */;
+		};
+		9077A67E1E549324004FABE8 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Diff;
+			targetProxy = 9077A67D1E549324004FABE8 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 

--- a/Bond.xcodeproj/project.pbxproj
+++ b/Bond.xcodeproj/project.pbxproj
@@ -625,7 +625,6 @@
 				16210A371D3EC474004AEDF3 /* Sources */,
 				16210A381D3EC474004AEDF3 /* Frameworks */,
 				16210A391D3EC474004AEDF3 /* Headers */,
-				16210A3A1D3EC474004AEDF3 /* Resources */,
 			);
 			buildRules = (
 			);
@@ -682,7 +681,6 @@
 				16D30EA91D6591D300C2435D /* Sources */,
 				16D30EAA1D6591D300C2435D /* Frameworks */,
 				16D30EAB1D6591D300C2435D /* Headers */,
-				16D30EAC1D6591D300C2435D /* Resources */,
 			);
 			buildRules = (
 			);
@@ -702,7 +700,6 @@
 				16D30ED11D65D11900C2435D /* Sources */,
 				16D30ED21D65D11900C2435D /* Frameworks */,
 				16D30ED31D65D11900C2435D /* Headers */,
-				16D30ED41D65D11900C2435D /* Resources */,
 			);
 			buildRules = (
 			);
@@ -837,13 +834,6 @@
 /* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
-		16210A3A1D3EC474004AEDF3 /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		16210A431D3EC474004AEDF3 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -856,20 +846,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				16887E441D744ABB00EDA099 /* LaunchScreen.storyboard in Resources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		16D30EAC1D6591D300C2435D /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		16D30ED41D65D11900C2435D /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
I've been having huge troubles getting syntax highlighting and autocompletion working with Xcode lately. Making the dependencies explicit in Xcode seems to help (even though it _should_ be unnecessary).