### PR TITLE
Update Diff.swift to version 0.5.2

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "wokalski/Diff.swift" "0.5.1"
+github "wokalski/Diff.swift" "0.5.2"
 github "ReactiveKit/ReactiveKit" "v3.3.1"


### PR DESCRIPTION
v0.5.2 has fixes for warnings shown under the Xcode 8.3 betas