### PR TITLE
Provide default values for ObservableDictionary and ObservableSet initializers

### DIFF
--- a/Sources/Collections/ObservableDictionary.swift
+++ b/Sources/Collections/ObservableDictionary.swift
@@ -44,7 +44,7 @@ public class ObservableDictionary<Key: Hashable, Value>: Collection, SignalProto
   fileprivate let subject = PublishSubject<ObservableDictionaryEvent<Key, Value>, NoError>()
   fileprivate let lock = NSRecursiveLock(name: "com.reactivekit.bond.observabledictionary")
 
-  public init(_ dictionary: Dictionary<Key, Value>) {
+  public init(_ dictionary: Dictionary<Key, Value> = [:]) {
     self.dictionary = dictionary
   }
 

--- a/Sources/Collections/ObservableSet.swift
+++ b/Sources/Collections/ObservableSet.swift
@@ -44,7 +44,7 @@ public class ObservableSet<Element: Hashable>: Collection, SignalProtocol {
   fileprivate let subject = PublishSubject<ObservableSetEvent<Element>, NoError>()
   fileprivate let lock = NSRecursiveLock(name: "com.reactivekit.bond.observableset")
 
-  public init(_ set: Set<Element>) {
+  public init(_ set: Set<Element> = []) {
     self.set = set
   }
 


### PR DESCRIPTION
This PR makes it simpler to initialise both `ObservableDictionary` and `ObservableSet`.

## Before

```swift
let initialDictionaryValue = [String: String]()
let observableDictionary = ObservableDictionary<[String: String]>(initialDictionaryValue)

let initialSetValue = Set<String>()
let observableDictionary = ObservableSet<String>(initialSetValue)
```

## After

```swift
let observableDictionary = ObservableDictionary<[String: String]>()

let observableDictionary = ObservableSet<String>()
```
