### PR TITLE
Update Diff.swift dependency to 0.5.3

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "Carthage/Checkouts/ReactiveKit"]
 	path = Carthage/Checkouts/ReactiveKit
-	url = ssh://git@github.com/ReactiveKit/ReactiveKit.git
+	url = https://github.com/ReactiveKit/ReactiveKit.git
 [submodule "Carthage/Checkouts/Diff.swift"]
 	path = Carthage/Checkouts/Diff.swift
-	url = ssh://git@github.com/wokalski/Diff.swift.git
+	url = https://github.com/wokalski/Diff.swift.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "Carthage/Checkouts/ReactiveKit"]
 	path = Carthage/Checkouts/ReactiveKit
-	url = https://github.com/ReactiveKit/ReactiveKit.git
+	url = ssh://git@github.com/ReactiveKit/ReactiveKit.git
 [submodule "Carthage/Checkouts/Diff.swift"]
 	path = Carthage/Checkouts/Diff.swift
-	url = https://github.com/wokalski/Diff.swift.git
+	url = ssh://git@github.com/wokalski/Diff.swift.git

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "wokalski/Diff.swift" "0.5.2"
+github "wokalski/Diff.swift" "0.5.3"
 github "ReactiveKit/ReactiveKit" "v3.3.1"


### PR DESCRIPTION
This dependency update includes fixes for Xcode 8.3 and Swift 3.1. 

Fixes #397.