### PR TITLE
Prep release of Bond 6.2.2

### DIFF
--- a/Bond.podspec
+++ b/Bond.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "Bond"
-  s.version      = "6.2.1"
+  s.version      = "6.2.2"
   s.summary      = "A Swift binding framework"
 
   s.description  = <<-DESC
@@ -21,7 +21,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = "8.0"
   s.osx.deployment_target = "10.10"
   s.tvos.deployment_target = '9.0'
-  s.source       = { :git => "https://github.com/SwiftBond/Bond.git", :tag => "6.2.1" }
+  s.source       = { :git => "https://github.com/SwiftBond/Bond.git", :tag => "6.2.2" }
   s.source_files  = 'Sources/**/*.swift', 'Bond/*.{h,m,swift}'
   s.ios.exclude_files = "Sources/AppKit"
   s.tvos.exclude_files = "Sources/AppKit"

--- a/Bond/Info.plist
+++ b/Bond/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>6.2.1</string>
+	<string>6.2.2</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>


### PR DESCRIPTION
This release only contains one change: 9b5ce4236ae256aced3d50290673624b9c5e15da

The Swift Package Manager package description (`Package.swift`) was missing a delimiter in the `dependencies` array.