### PR TITLE
Address two issues with batched updates and array replacement

### DIFF
--- a/Sources/Bond/Collections/ObservableArray.swift
+++ b/Sources/Bond/Collections/ObservableArray.swift
@@ -207,6 +207,7 @@ public class MutableObservableArray<Item>: ObservableArray<Item> {
 
     // if only reset, do not batch:
     if diff == [.reset] {
+      array = proxy.array
       subject.next(ObservableArrayEvent(change: .reset, source: self))
     } else if diff.count > 0 {
       // ...otherwise batch:

--- a/Sources/Bond/Collections/ObservableArray.swift
+++ b/Sources/Bond/Collections/ObservableArray.swift
@@ -296,30 +296,30 @@ extension MutableObservableArray {
 }
 
 extension MutableObservableArray where Item: Equatable {
-  
-  public func replace(with array: [Item], performDiff: Bool) {
-    if performDiff {
-      lock.lock()
 
+  public func replace(with array: [Item], performDiff: Bool) {
+    lock.lock(); defer { lock.unlock() }
+
+    if performDiff {
       let diff = self.array.extendedDiff(array)
+      let patch = diff.patch(from: self.array, to: array)
       subject.next(ObservableArrayEvent(change: .beginBatchEditing, source: self))
       self.array = array
 
-      for step in diff {
+      for step in patch {
         switch step {
-        case .insert(let index):
+        case .insertion(let index, _):
           subject.next(ObservableArrayEvent(change: .inserts([index]), source: self))
 
-        case .delete(let index):
+        case .deletion(let index):
           subject.next(ObservableArrayEvent(change: .deletes([index]), source: self))
 
         case .move(let from, let to):
           subject.next(ObservableArrayEvent(change: .move(from, to), source: self))
         }
       }
-      
+
       subject.next(ObservableArrayEvent(change: .endBatchEditing, source: self))
-      lock.unlock()
     } else {
       replace(with: array)
     }


### PR DESCRIPTION
This PR addresses two issues I've found while using these APIs in anger:

1. `batchUpdate(…)` did not apply changes from the proxy observable array if the diff generated a `.reset` entry;
2. Switched the logic behind `replace(…)` to use Diff.swift - it should be faster (YMMV) and it's consistent with other diffs in the framework.