### PR TITLE
Update Swift 4 branch to include recent changes to patches and diffs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
-language: objective-c
-osx_image: xcode8.3
+language: swift
+osx_image: xcode9
 
 # Travis is currently experiencing issues with Xcode builds: https://github.com/travis-ci/travis-ci/issues/6675#issuecomment-257964767
 # When this is resolved, remove the entire `before_install` block, as well as the `travis_retry` command below.
 before_install:
-  - export IOS_SIMULATOR_UDID=`instruments -s devices | grep "iPhone 7 (10.1" | awk -F '[ ]' '{print $4}' | awk -F '[\[]' '{print $2}' | sed 's/.$//'`
+  - export IOS_SIMULATOR_UDID=`instruments -s devices | grep "iPhone 7 (11.0" | awk -F '[ ]' '{print $4}' | awk -F '[\[]' '{print $2}' | sed 's/.$//'`
   - echo $IOS_SIMULATOR_UDID
   - open -a "simulator" --args -CurrentDeviceUDID $IOS_SIMULATOR_UDID
 
@@ -12,7 +12,7 @@ install:
   - gem install xcpretty
 
 script:
-  - set -o pipefail && travis_retry xcodebuild -project Bond.xcodeproj -scheme Bond-iOS -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 7,OS=10.1' test | xcpretty
+  - set -o pipefail && travis_retry xcodebuild -project Bond.xcodeproj -scheme Bond-iOS -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 7,OS=11.0' test | xcpretty
   - swift test --parallel
 
 after_success:

--- a/Bond.xcodeproj/project.pbxproj
+++ b/Bond.xcodeproj/project.pbxproj
@@ -72,11 +72,8 @@
 		90A4433A1E9055D800D611FE /* UIView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90C04D551E8F0B1D000077C8 /* UIView.swift */; };
 		90A4435D1E90594000D611FE /* Diff.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 90A3FAC81E0C8D8B0086A7F1 /* Diff.framework */; };
 		90A4437A1E91390000D611FE /* BNDProtocolProxyBase.m in Sources */ = {isa = PBXBuildFile; fileRef = 90C04D161E8F0B12000077C8 /* BNDProtocolProxyBase.m */; };
-		90A4437B1E91390900D611FE /* BNDProtocolProxyBase.h in Headers */ = {isa = PBXBuildFile; fileRef = 90C04D181E8F0B12000077C8 /* BNDProtocolProxyBase.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		90A4437C1E91391800D611FE /* BNDProtocolProxyBase.h in Headers */ = {isa = PBXBuildFile; fileRef = 90C04D181E8F0B12000077C8 /* BNDProtocolProxyBase.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		90A4437D1E91391B00D611FE /* BNDProtocolProxyBase.m in Sources */ = {isa = PBXBuildFile; fileRef = 90C04D161E8F0B12000077C8 /* BNDProtocolProxyBase.m */; };
 		90A4437E1E91391D00D611FE /* BNDProtocolProxyBase.m in Sources */ = {isa = PBXBuildFile; fileRef = 90C04D161E8F0B12000077C8 /* BNDProtocolProxyBase.m */; };
-		90A4437F1E91392100D611FE /* BNDProtocolProxyBase.h in Headers */ = {isa = PBXBuildFile; fileRef = 90C04D181E8F0B12000077C8 /* BNDProtocolProxyBase.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		90C04D081E8F0AD4000077C8 /* Bond.h in Headers */ = {isa = PBXBuildFile; fileRef = 90C04D031E8F0A97000077C8 /* Bond.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		90C04D091E8F0AD5000077C8 /* Bond.h in Headers */ = {isa = PBXBuildFile; fileRef = 90C04D031E8F0A97000077C8 /* Bond.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		90C04D0A1E8F0AD5000077C8 /* Bond.h in Headers */ = {isa = PBXBuildFile; fileRef = 90C04D031E8F0A97000077C8 /* Bond.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -200,6 +197,9 @@
 		90C04DDC1E8F0BAF000077C8 /* UITableViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90C04DD11E8F0BA7000077C8 /* UITableViewTests.swift */; };
 		EC86E9AF1E9145CC008563B2 /* UIAccessibilityIdentification.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC86E9AE1E9145CC008563B2 /* UIAccessibilityIdentification.swift */; };
 		EC86E9B01E9145CC008563B2 /* UIAccessibilityIdentification.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC86E9AE1E9145CC008563B2 /* UIAccessibilityIdentification.swift */; };
+		EC893EC41F07A164007981EC /* BNDProtocolProxyBase.h in Headers */ = {isa = PBXBuildFile; fileRef = 90C04D181E8F0B12000077C8 /* BNDProtocolProxyBase.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EC893EC51F07A164007981EC /* BNDProtocolProxyBase.h in Headers */ = {isa = PBXBuildFile; fileRef = 90C04D181E8F0B12000077C8 /* BNDProtocolProxyBase.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		EC893EC61F07A164007981EC /* BNDProtocolProxyBase.h in Headers */ = {isa = PBXBuildFile; fileRef = 90C04D181E8F0B12000077C8 /* BNDProtocolProxyBase.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EC9693661D947243004EB5EE /* Bond.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 16210A3C1D3EC474004AEDF3 /* Bond.framework */; };
 		EC9693671D94724C004EB5EE /* ReactiveKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1652178B1D70591E00C9FAEE /* ReactiveKit.framework */; };
 /* End PBXBuildFile section */
@@ -683,7 +683,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				90C04D081E8F0AD4000077C8 /* Bond.h in Headers */,
-				90A4437B1E91390900D611FE /* BNDProtocolProxyBase.h in Headers */,
+				EC893EC41F07A164007981EC /* BNDProtocolProxyBase.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -692,7 +692,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				90C04D091E8F0AD5000077C8 /* Bond.h in Headers */,
-				90A4437C1E91391800D611FE /* BNDProtocolProxyBase.h in Headers */,
+				EC893EC51F07A164007981EC /* BNDProtocolProxyBase.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -701,7 +701,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				90C04D0A1E8F0AD5000077C8 /* Bond.h in Headers */,
-				90A4437F1E91392100D611FE /* BNDProtocolProxyBase.h in Headers */,
+				EC893EC61F07A164007981EC /* BNDProtocolProxyBase.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1269,7 +1269,9 @@
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG BUILDING_WITH_XCODE";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SYSTEM_FRAMEWORK_SEARCH_PATHS = "";
 				TARGETED_DEVICE_FAMILY = "1,2";
+				USER_HEADER_SEARCH_PATHS = "";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -1321,7 +1323,9 @@
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = BUILDING_WITH_XCODE;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SYSTEM_FRAMEWORK_SEARCH_PATHS = "";
 				TARGETED_DEVICE_FAMILY = "1,2";
+				USER_HEADER_SEARCH_PATHS = "";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";

--- a/Sources/Bond/AppKit/NSTableView.swift
+++ b/Sources/Bond/AppKit/NSTableView.swift
@@ -44,7 +44,7 @@ public protocol TableViewBond {
 	
 	associatedtype DataSource: DataSourceProtocol
 	
-	func apply(event: DataSourceEvent<DataSource>, to tableView: NSTableView)
+	func apply(event: DataSourceEvent<DataSource, BatchKindPatch>, to tableView: NSTableView)
 	func heightForRow(at index: Int, tableView: NSTableView, dataSource: DataSource) -> CGFloat?
 	func cellForRow(at index: Int, tableView: NSTableView, dataSource: DataSource) -> NSView?
 }
@@ -55,7 +55,7 @@ extension TableViewBond {
 		return nil
 	}
 
-	public func apply(event: DataSourceEvent<DataSource>, to tableView: NSTableView) {
+	public func apply(event: DataSourceEvent<DataSource, BatchKindPatch>, to tableView: NSTableView) {
 		tableView.reloadData()
 	}
 }
@@ -91,7 +91,7 @@ open class DefaultTableViewBond<DataSource: DataSourceProtocol>: TableViewBond {
 		return createCell?(dataSource, index, tableView) ?? nil
 	}
 	
-	open func apply(event: DataSourceEvent<DataSource>, to tableView: NSTableView) {
+	open func apply(event: DataSourceEvent<DataSource, BatchKindPatch>, to tableView: NSTableView) {
 		if insertAnimation == nil && deleteAnimation == nil {
 			tableView.reloadData()
 			return
@@ -141,7 +141,9 @@ private struct ReloadingTableViewBond<DataSource: DataSourceProtocol>: TableView
 
 // MARK: - Bond implementation
 
-public extension SignalProtocol where Element: DataSourceEventProtocol, Element.DataSource: QueryableDataSourceProtocol, Element.DataSource.Item: Any, Element.DataSource.Index == Int, Error == NoError {
+public extension SignalProtocol where
+    Element: DataSourceEventProtocol, Element.BatchKind == BatchKindPatch,
+    Element.DataSource: QueryableDataSourceProtocol, Element.DataSource.Index == Int, Error == NoError {
 
   public typealias DataSource = Element.DataSource
 	
@@ -153,9 +155,14 @@ public extension SignalProtocol where Element: DataSourceEventProtocol, Element.
 			return bind(to: tableView, using: ReloadingTableViewBond<DataSource>(createCell: createCell))
 		}
 	}
-	
+
+  @discardableResult
+  public func bind<B: TableViewBond>(to tableView: NSTableView, using bond: B) -> Disposable where B.DataSource == DataSource {
+    return _bind(to: tableView, using: bond)
+  }
+
 	@discardableResult
-	public func bind<B: TableViewBond>(to tableView: NSTableView, using bond: B) -> Disposable where B.DataSource == DataSource {
+	fileprivate func _bind<B: TableViewBond>(to tableView: NSTableView, using bond: B) -> Disposable where B.DataSource == DataSource {
 	
     let dataSource = Property<DataSource?>(nil)
     let disposable = CompositeDisposable()
@@ -189,7 +196,7 @@ public extension SignalProtocol where Element: DataSourceEventProtocol, Element.
       property: dataSource,
       to: #selector(NSTableViewDataSource.tableView(_:objectValueFor:row:)),
       map: { (dataSource: DataSource?, _: NSTableView, _: NSTableColumn, row: Int) -> Any? in
-        return dataSource?.item(at: row)
+        return dataSource?[row]
       }
     )
 
@@ -200,6 +207,40 @@ public extension SignalProtocol where Element: DataSourceEventProtocol, Element.
     }
 
     return disposable
+  }
+}
+
+public extension SignalProtocol where Element: ObservableArrayEventProtocol, Error == NoError {
+
+  @discardableResult
+  public func bind(to tableView: NSTableView, animated: Bool = true, createCell: @escaping (ObservableArray<Element.Item>, Int, NSTableView) -> NSView?) -> Disposable {
+    if animated {
+      return toPatchesByResettingBatch()._bind(to: tableView, using: DefaultTableViewBond<ObservableArray<Element.Item>>(createCell: createCell))
+    } else {
+      return toPatchesByResettingBatch()._bind(to: tableView, using: ReloadingTableViewBond<ObservableArray<Element.Item>>(createCell: createCell))
+    }
+  }
+
+  @discardableResult
+  public func bind<B: TableViewBond>(to tableView: NSTableView, using bond: B) -> Disposable where B.DataSource == ObservableArray<Element.Item> {
+    return toPatchesByResettingBatch()._bind(to: tableView, using: bond)
+  }
+}
+
+public extension SignalProtocol where Element: ObservableArrayEventProtocol, Element.Item: Equatable, Error == NoError {
+
+  @discardableResult
+  public func bind(to tableView: NSTableView, animated: Bool = true, createCell: @escaping (ObservableArray<Element.Item>, Int, NSTableView) -> NSView?) -> Disposable {
+    if animated {
+      return toPatches()._bind(to: tableView, using: DefaultTableViewBond<ObservableArray<Element.Item>>(createCell: createCell))
+    } else {
+      return toPatches()._bind(to: tableView, using: ReloadingTableViewBond<ObservableArray<Element.Item>>(createCell: createCell))
+    }
+  }
+
+  @discardableResult
+  public func bind<B: TableViewBond>(to tableView: NSTableView, using bond: B) -> Disposable where B.DataSource == ObservableArray<Element.Item> {
+    return toPatches()._bind(to: tableView, using: bond)
   }
 }
 

--- a/Sources/Bond/AppKit/NSTableView.swift
+++ b/Sources/Bond/AppKit/NSTableView.swift
@@ -196,7 +196,7 @@ public extension SignalProtocol where
       property: dataSource,
       to: #selector(NSTableViewDataSource.tableView(_:objectValueFor:row:)),
       map: { (dataSource: DataSource?, _: NSTableView, _: NSTableColumn, row: Int) -> Any? in
-        return dataSource?[row]
+        return dataSource?.item(at: row)
       }
     )
 

--- a/Sources/Bond/Collections/Observable2DArray.swift
+++ b/Sources/Bond/Collections/Observable2DArray.swift
@@ -406,7 +406,12 @@ extension Observable2DArrayPatchEvent: DataSourceEventProtocol {
   }
 }
 
-extension Observable2DArray: QueryableDataSourceProtocol {}
+extension Observable2DArray: QueryableDataSourceProtocol {
+
+  public func item(at index: IndexPath) -> Item {
+    return self[index]
+  }
+}
 
 extension MutableObservable2DArray {
 

--- a/Sources/Bond/Collections/Observable2DArray.swift
+++ b/Sources/Bond/Collections/Observable2DArray.swift
@@ -50,7 +50,22 @@ public protocol Observable2DArrayEventProtocol {
   var source: Observable2DArray<SectionMetadata, Item> { get }
 }
 
-public struct Observable2DArrayEvent<SectionMetadata, Item> {
+public struct Observable2DArrayEvent<SectionMetadata, Item>: Observable2DArrayEventProtocol {
+  public let change: Observable2DArrayChange
+  public let source: Observable2DArray<SectionMetadata, Item>
+
+  public init(change: Observable2DArrayChange, source: Observable2DArray<SectionMetadata, Item>) {
+    self.change = change
+    self.source = source
+  }
+
+  public init(change: Observable2DArrayChange, source: [Observable2DArraySection<SectionMetadata, Item>]) {
+    self.change = change
+    self.source = Observable2DArray(source)
+  }
+}
+
+public struct Observable2DArrayPatchEvent<SectionMetadata, Item>: Observable2DArrayEventProtocol {
   public let change: Observable2DArrayChange
   public let source: Observable2DArray<SectionMetadata, Item>
 
@@ -313,14 +328,6 @@ public class MutableObservable2DArray<SectionMetadata, Item>: Observable2DArray<
     }
   }
 
-  /// Perform batched updates on the array.
-  public func batchUpdate(_ update: (MutableObservable2DArray<SectionMetadata, Item>) -> Void) {
-    lock.lock(); defer { lock.unlock() }
-    subject.next(Observable2DArrayEvent(change: .beginBatchEditing, source: self))
-    update(self)
-    subject.next(Observable2DArrayEvent(change: .endBatchEditing, source: self))
-  }
-
   /// Change the underlying value withouth notifying the observers.
   public func silentUpdate(_ update: (inout [Observable2DArraySection<SectionMetadata, Item>]) -> Void) {
     lock.lock(); defer { lock.unlock() }
@@ -343,10 +350,10 @@ extension MutableObservable2DArray: BindableProtocol {
 
 // MARK: DataSourceProtocol conformation
 
-extension Observable2DArrayEvent: DataSourceEventProtocol {
+extension Observable2DArrayChange {
 
-  public var kind: DataSourceEventKind {
-    switch change {
+  public var asDataSourceEventKind: DataSourceEventKind {
+    switch self {
     case .reset:
       return .reload
     case .insertItems(let indexPaths):
@@ -371,20 +378,35 @@ extension Observable2DArrayEvent: DataSourceEventProtocol {
       return .endUpdates
     }
   }
+}
+
+extension Observable2DArrayEvent: DataSourceEventProtocol {
+
+  public typealias BatchKind = BatchKindDiff
+
+  public var kind: DataSourceEventKind {
+    return change.asDataSourceEventKind
+  }
 
   public var dataSource: Observable2DArray<SectionMetadata, Item> {
     return source
   }
 }
 
-extension Observable2DArray: DataSourceProtocol {}
+extension Observable2DArrayPatchEvent: DataSourceEventProtocol {
 
-extension Observable2DArray: QueryableDataSourceProtocol {
+  public typealias BatchKind = BatchKindPatch
 
-  public func item(at index: IndexPath) -> Item {
-    return self[index]
+  public var kind: DataSourceEventKind {
+    return change.asDataSourceEventKind
+  }
+
+  public var dataSource: Observable2DArray<SectionMetadata, Item> {
+    return source
   }
 }
+
+extension Observable2DArray: QueryableDataSourceProtocol {}
 
 extension MutableObservable2DArray {
 
@@ -401,7 +423,6 @@ extension MutableObservable2DArray {
     sections = array.sections
     subject.next(Observable2DArrayEvent(change: .reset, source: self))
   }
-
 }
 
 extension MutableObservable2DArray where Item: Equatable {
@@ -452,6 +473,13 @@ extension MutableObservable2DArray where Item: Equatable {
 }
 
 extension MutableObservable2DArray where Item: Equatable, SectionMetadata: Equatable {
+
+  /// Perform batched updates on the array.
+  public func batchUpdate(_ update: (MutableObservable2DArray<SectionMetadata, Item>) -> Void) {
+    let copy = MutableObservable2DArray(sections)
+    update(copy)
+    replace(with: copy, performDiff: true)
+  }
 
   /// Replace the entire 2DArray performing nested diff (if preformDiff is true) on all
   /// sections and section's items resulting in a series of events (deleteSection,
@@ -544,5 +572,41 @@ fileprivate struct NestedBatchUpdate {
     self.sectionMoves = sectionMoves
     self.sectionInsertions = sectionInsertions
     self.sectionDeletions = sectionDeletions
+  }
+}
+
+public extension SignalProtocol where Element: Observable2DArrayEventProtocol {
+
+  /// Converts diff events into patch events by transforming batch updates into resets (i.e. disabling batch updates).
+  public func toPatchesByResettingBatch() -> Signal<Observable2DArrayPatchEvent<Element.SectionMetadata, Element.Item>, Error> {
+
+    var isBatching = false
+
+    return Signal { observer in
+      return self.observe { event in
+        switch event {
+        case .next(let observableArrayEvent):
+
+          let source = observableArrayEvent.source
+          switch observableArrayEvent.change {
+          case .beginBatchEditing:
+            isBatching = true
+          case .endBatchEditing:
+            isBatching = false
+            observer.next(.init(change: .reset, source: source))
+          default:
+            if !isBatching {
+              observer.next(.init(change: observableArrayEvent.change, source: source))
+            }
+          }
+
+        case .failed(let error):
+          observer.failed(error)
+
+        case .completed:
+          observer.completed()
+        }
+      }
+    }
   }
 }

--- a/Sources/Bond/Collections/ObservableArray.swift
+++ b/Sources/Bond/Collections/ObservableArray.swift
@@ -313,6 +313,10 @@ extension ObservableArrayPatchEvent: DataSourceEventProtocol {
 }
 
 extension ObservableArray: QueryableDataSourceProtocol {
+
+  public func item(at index: Int) -> Item {
+    return self[index]
+  }
   
   public var numberOfSections: Int {
     return 1

--- a/Sources/Bond/Collections/ObservableArray.swift
+++ b/Sources/Bond/Collections/ObservableArray.swift
@@ -229,6 +229,7 @@ public class MutableObservableArray<Item>: ObservableArray<Item> {
 
     // if only reset, do not batch:
     if diff == [.reset] {
+      array = proxy.array
       subject.next(ObservableArrayEvent(change: .reset, source: self))
     } else if diff.count > 0 {
       // ...otherwise batch:

--- a/Sources/Bond/QueryableDataSource.swift
+++ b/Sources/Bond/QueryableDataSource.swift
@@ -25,13 +25,7 @@
 public protocol QueryableDataSourceProtocol: DataSourceProtocol {
   associatedtype Item
   associatedtype Index
-
-  func item(at index: Index) -> Item
+  subscript(_ index: Index) -> Item { get }
 }
 
-extension Array: QueryableDataSourceProtocol {
-
-  public func item(at index: Int) -> Iterator.Element {
-    return self[index]
-  }
-}
+extension Array: QueryableDataSourceProtocol {}

--- a/Sources/Bond/QueryableDataSource.swift
+++ b/Sources/Bond/QueryableDataSource.swift
@@ -25,7 +25,13 @@
 public protocol QueryableDataSourceProtocol: DataSourceProtocol {
   associatedtype Item
   associatedtype Index
-  subscript(_ index: Index) -> Item { get }
+
+  func item(at index: Index) -> Item
 }
 
-extension Array: QueryableDataSourceProtocol {}
+extension Array: QueryableDataSourceProtocol {
+
+  public func item(at index: Int) -> Iterator.Element {
+    return self[index]
+  }
+}

--- a/Sources/Bond/UIKit/UICollectionView.swift
+++ b/Sources/Bond/UIKit/UICollectionView.swift
@@ -52,7 +52,7 @@ public extension ReactiveExtensions where Base: UICollectionView {
   }
 }
 
-public extension SignalProtocol where Element: DataSourceEventProtocol, Error == NoError {
+public extension SignalProtocol where Element: DataSourceEventProtocol, Element.BatchKind == BatchKindDiff, Error == NoError {
 
   @discardableResult
   public func bind(to collectionView: UICollectionView, createCell: @escaping (DataSource, IndexPath, UICollectionView) -> UICollectionViewCell) -> Disposable {

--- a/Sources/Bond/UIKit/UITableView.swift
+++ b/Sources/Bond/UIKit/UITableView.swift
@@ -42,7 +42,7 @@ public protocol TableViewBond {
 
   associatedtype DataSource: DataSourceProtocol
 
-  func apply(event: DataSourceEvent<DataSource>, to tableView: UITableView)
+  func apply(event: DataSourceEvent<DataSource, BatchKindDiff>, to tableView: UITableView)
   func cellForRow(at indexPath: IndexPath, tableView: UITableView, dataSource: DataSource) -> UITableViewCell
   func titleForHeader(in section: Int, dataSource: DataSource) -> String?
   func titleForFooter(in section: Int, dataSource: DataSource) -> String?
@@ -50,7 +50,7 @@ public protocol TableViewBond {
 
 extension TableViewBond {
 
-  public func apply(event: DataSourceEvent<DataSource>, to tableView: UITableView) {
+  public func apply(event: DataSourceEvent<DataSource, BatchKindDiff>, to tableView: UITableView) {
     switch event.kind {
     case .reload:
       tableView.reloadData()
@@ -103,12 +103,12 @@ private struct ReloadingTableViewBond<DataSource: DataSourceProtocol>: TableView
     return createCell(dataSource, indexPath, tableView)
   }
 
-  func apply(event: DataSourceEvent<DataSource>, to tableView: UITableView) {
+  func apply(event: DataSourceEvent<DataSource, BatchKindDiff>, to tableView: UITableView) {
     tableView.reloadData()
   }
 }
 
-public extension SignalProtocol where Element: DataSourceEventProtocol, Error == NoError {
+public extension SignalProtocol where Element: DataSourceEventProtocol, Element.BatchKind == BatchKindDiff, Error == NoError {
 
   public typealias DataSource = Element.DataSource
 


### PR DESCRIPTION
As per the label on the box ☝️ 

Gosh the lack of subscripts on the main `Observable*` collection types hurts the API, doesn't it? 😢