### PR TITLE
Fixed crash on binding to NSTableView

### DIFF
--- a/Sources/Bond/AppKit/NSTableView.swift
+++ b/Sources/Bond/AppKit/NSTableView.swift
@@ -196,7 +196,7 @@ public extension SignalProtocol where
       property: dataSource,
       to: #selector(NSTableViewDataSource.tableView(_:objectValueFor:row:)),
       map: { (dataSource: DataSource?, _: NSTableView, _: NSTableColumn, row: Int) -> Any? in
-        return dataSource?[row]
+        return dataSource?[row] as AnyObject
       }
     )
 


### PR DESCRIPTION
```
* thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=1, address=0x775400656e68)
    frame #0: 0x00007fffca525f31 libobjc.A.dylib`objc_retain + 33
  * frame #1: 0x00000001000b5c4e Bond`__42-[BNDProtocolProxyBase forwardInvocation:]_block_invoke.21((null)=<unavailable>, buffer=0x00007fff5fbfdd40) at BNDProtocolProxyBase.m:79
    frame #2: 0x0000000100130940 Bond`thunk at ProtocolProxy.swift:0
    frame #3: 0x00000001001303d7 Bond`thunk at ProtocolProxy.swift:0
    frame #4: 0x000000010013dc01 Bond`partial apply for thunk at ProtocolProxy.swift:0
    frame #5: 0x0000000100130560 Bond`thunk at ProtocolProxy.swift:0
    frame #6: 0x0000000100132783 Bond`ProtocolProxy.(extractor=0x000000010013dc50 Bond`partial apply forwarder for reabstraction thunk helper from @callee_owned (@in (Swift.Int, Swift.Optional<Swift.UnsafeMutableRawPointer>)) -> (@out ()) to @callee_owned (@unowned Swift.Int, @unowned Swift.Optional<Swift.UnsafeMutableRawPointer>) -> () at ProtocolProxy.swift, setReturnValue=0x000000010013dce0 Bond`partial apply forwarder for reabstraction thunk helper from @callee_owned (@in Swift.Optional<Swift.UnsafeMutableRawPointer>) -> (@out ()) to @callee_owned (@unowned Swift.Optional<Swift.UnsafeMutableRawPointer>) -> () at ProtocolProxy.swift, block=0x000000010013d550 Bond`partial apply forwarder for Bond.ProtocolProxy.(signal <A, B, C, D, E> (for : ObjectiveC.Selector, dispatch : (ReactiveKit.PublishSubject<D, ReactiveKit.NoError>, A, B, C) -> E) -> ReactiveKit.Signal<D, ReactiveKit.NoError>).(closure #1).(closure #1) at ProtocolProxy.swift) -> D) -> Disposable).(closure #1) at ProtocolProxy.swift:113
    frame #7: 0x000000010013c2e8 Bond`partial apply for ProtocolProxy.(registerInvoker<A, B, C, D> (for : Selector, block : (A, B, C) -> D) -> Disposable).(closure #1) at ProtocolProxy.swift:0
    frame #8: 0x00000001001304fa Bond`thunk at ProtocolProxy.swift:0
    frame #9: 0x000000010013c421 Bond`partial apply for thunk at ProtocolProxy.swift:0
    frame #10: 0x0000000100130385 Bond`thunk at ProtocolProxy.swift:0
    frame #11: 0x0000000100130793 Bond`ProtocolProxy.invoke(selector="tableView:objectValueForTableColumn:row:", argumentExtractor=0x00000001001378c0 Bond`partial apply forwarder for reabstraction thunk helper from @callee_unowned @convention(block) (@unowned Swift.Int, @unowned Swift.Optional<Swift.UnsafeMutableRawPointer>) -> () to @callee_owned (@unowned Swift.Int, @unowned Swift.Optional<Swift.UnsafeMutableRawPointer>) -> () at ProtocolProxy.swift, setReturnValue=0x0000000100137950 Bond`partial apply forwarder for reabstraction thunk helper from @callee_unowned @convention(block) (@unowned Swift.Optional<Swift.UnsafeMutableRawPointer>) -> () to @callee_owned (@unowned Swift.Optional<Swift.UnsafeMutableRawPointer>) -> () at ProtocolProxy.swift, self=0x0000600000074480) -> (), setReturnValue : (UnsafeMutableRawPointer?) -> ()?) -> () at ProtocolProxy.swift:71
    frame #12: 0x00000001001308c8 Bond`@objc ProtocolProxy.invoke(with : Selector, argumentExtractor : (Int, UnsafeMutableRawPointer?) -> (), setReturnValue : (UnsafeMutableRawPointer?) -> ()?) -> () at ProtocolProxy.swift:0
    frame #13: 0x00000001000b595c Bond`-[BNDProtocolProxyBase forwardInvocation:](self=0x0000600000074480, _cmd="forwardInvocation:", invocation=0x000060000006c1c0) at BNDProtocolProxyBase.m:76
    frame #14: 0x00007fffb569654a CoreFoundation`___forwarding___ + 538
    frame #15: 0x00007fffb56962a8 CoreFoundation`__forwarding_prep_0___ + 120
    frame #16: 0x00007fffb32a80bb AppKit`-[NSTableRowData _addViewToRowView:atColumn:row:] + 536
    frame #17: 0x00007fffb32a7d1b AppKit`-[NSTableRowData _addViewsToRowView:atRow:] + 204
    frame #18: 0x00007fffb32a64bf AppKit`-[NSTableRowData _initializeRowView:atRow:] + 390
    frame #19: 0x00007fffb32a4ac5 AppKit`-[NSTableRowData _addRowViewForVisibleRow:withPriorView:] + 398
    frame #20: 0x00007fffb32a4880 AppKit`-[NSTableRowData _addRowViewForVisibleRow:withPriorRowIndex:inDictionary:withRowAnimation:] + 316
    frame #21: 0x00007fffb32a35b3 AppKit`-[NSTableRowData _unsafeUpdateVisibleRowEntries] + 1647
    frame #22: 0x00007fffb32a2ea6 AppKit`-[NSTableRowData updateVisibleRowViews] + 232
    frame #23: 0x00007fffb32a27ea AppKit`-[NSTableView layout] + 178
    frame #24: 0x00007fffb3a12246 AppKit`_NSViewLayout + 450
    frame #25: 0x00007fffb3243513 AppKit`-[NSView _doLayout] + 126
    frame #26: 0x00007fffb3243098 AppKit`-[NSView _layoutSubtreeWithOldSize:] + 497
    frame #27: 0x00007fffb3243366 AppKit`-[NSView _layoutSubtreeWithOldSize:] + 1215
    frame #28: 0x00007fffb3243366 AppKit`-[NSView _layoutSubtreeWithOldSize:] + 1215
    frame #29: 0x00007fffb3243366 AppKit`-[NSView _layoutSubtreeWithOldSize:] + 1215
    frame #30: 0x00007fffb3243366 AppKit`-[NSView _layoutSubtreeWithOldSize:] + 1215
    frame #31: 0x00007fffb3243366 AppKit`-[NSView _layoutSubtreeWithOldSize:] + 1215
    frame #32: 0x00007fffb3a1895b AppKit`-[NSView _layoutSubtreeIfNeededAndAllowTemporaryEngine:] + 1516
    frame #33: 0x00007fffb3261869 AppKit`-[NSWindow(NSConstraintBasedLayout) _layoutViewTree] + 163
    frame #34: 0x00007fffb32d0c2e AppKit`-[NSWindow(NSConstraintBasedLayout) layoutIfNeeded] + 269
    frame #35: 0x00007fffb32d0b08 AppKit`-[NSWindow _setUpFirstResponderBeforeBecomingVisible] + 63
    frame #36: 0x00007fffb32cff3d AppKit`-[NSWindow _doWindowWillBeVisibleAsSheet:] + 169
    frame #37: 0x00007fffb3a3663e AppKit`-[NSWindow _reallyDoOrderWindowAboveOrBelow:relativeTo:findKey:forCounter:force:isModal:] + 1514
    frame #38: 0x00007fffb32ce6ce AppKit`-[NSWindow _doOrderWindow:relativeTo:findKey:forCounter:force:isModal:] + 1041
    frame #39: 0x00007fffb32ce263 AppKit`-[NSWindow orderWindow:relativeTo:] + 153
    frame #40: 0x00007fffb3380bab AppKit`-[NSWindow makeKeyAndOrderFront:] + 111
    frame #41: 0x00007fffbb156519 QuickLookUI`-[QLSeamlessDocumentOpener showWindow:contentFrame:withBlock:] + 108
    frame #42: 0x00007fffb337fd37 AppKit`-[NSWindowController showWindow:] + 689
    frame #43: 0x00007fffb3152d2e AppKit`NSApplicationMain + 1013
    frame #44: 0x0000000100002b8d BondFix`main at AppDelegate.swift:12
    frame #45: 0x00007fffcae1a235 libdyld.dylib`start + 1
```

Demo project to reproduce the bug https://github.com/nayzak/BondBugDemo.