### PR TITLE
Make a number of NSControl objectValue derivative properties DynamicSubjects rather than Bonds

### DIFF
--- a/Sources/Bond/AppKit/NSControl.swift
+++ b/Sources/Bond/AppKit/NSControl.swift
@@ -74,36 +74,88 @@ public extension ReactiveExtensions where Base: NSControl {
     return controlEvent.map(read)
   }
 
-  public var isEnabled: Bond<Bool> {
-    return bond { $0.isEnabled = $1 }
+  public var isEnabled: DynamicSubject<Bool> {
+    return dynamicSubject(
+      signal: controlEvent.eraseType(),
+      triggerEventOnSetting: false,
+      get: { $0.isEnabled },
+      set: { $0.isEnabled = $1 }
+    )
   }
 
-  public var isHighlighted: Bond<Bool> {
-    return bond { $0.isHighlighted = $1 }
+  public var isHighlighted: DynamicSubject<Bool> {
+    return dynamicSubject(
+      signal: controlEvent.eraseType(),
+      triggerEventOnSetting: false,
+      get: { $0.isHighlighted },
+      set: { $0.isHighlighted = $1 }
+    )
   }
 
-  public var objectValue: Bond<AnyObject?> {
-    return bond { $0.objectValue = $1 }
+  public var objectValue: DynamicSubject<Any?> {
+    return dynamicSubject(
+      signal: controlEvent.eraseType(),
+      triggerEventOnSetting: false,
+      get: { $0.objectValue },
+      set: { $0.objectValue = $1 }
+    )
   }
 
-  public var stringValue: Bond<String> {
-    return bond { $0.stringValue = $1 }
+  public var stringValue: DynamicSubject<String> {
+    return dynamicSubject(
+      signal: controlEvent.eraseType(),
+      triggerEventOnSetting: false,
+      get: { $0.stringValue },
+      set: { $0.stringValue = $1 }
+    )
   }
 
-  public var attributedStringleValue: Bond<NSAttributedString> {
-    return bond { $0.attributedStringValue = $1 }
+  public var attributedStringValue: DynamicSubject<NSAttributedString> {
+    return dynamicSubject(
+      signal: controlEvent.eraseType(),
+      triggerEventOnSetting: false,
+      get: { $0.attributedStringValue },
+      set: { $0.attributedStringValue = $1 }
+    )
   }
 
-  public var integerValue: Bond<Int> {
-    return bond { $0.integerValue = $1 }
+  public var integerValue: DynamicSubject<Int> {
+    return dynamicSubject(
+      signal: controlEvent.eraseType(),
+      triggerEventOnSetting: false,
+      get: { $0.integerValue },
+      set: { $0.integerValue = $1 }
+    )
   }
 
-  public var floatValue: Bond<Float> {
-    return bond { $0.floatValue = $1 }
+  public var floatValue: DynamicSubject<Float> {
+    return dynamicSubject(
+      signal: controlEvent.eraseType(),
+      triggerEventOnSetting: false,
+      get: { $0.floatValue },
+      set: { $0.floatValue = $1 }
+    )
   }
 
-  public var doubleValue: Bond<Double> {
-    return bond { $0.doubleValue = $1 }
+  public var doubleValue: DynamicSubject<Double> {
+    return dynamicSubject(
+      signal: controlEvent.eraseType(),
+      triggerEventOnSetting: false,
+      get: { $0.doubleValue },
+      set: { $0.doubleValue = $1 }
+    )
+  }
+
+  @available(*, deprecated, message: "Use attributedStringValue instead.")
+  public var attributedStringleValue: DynamicSubject<NSAttributedString> {
+    return attributedStringValue
+  }
+}
+
+extension NSControl: BindableProtocol {
+
+  public func bind(signal: Signal<Any?, NoError>) -> Disposable {
+    return reactive.objectValue.bind(signal: signal)
   }
 }
 

--- a/Sources/Bond/AppKit/NSImageView.swift
+++ b/Sources/Bond/AppKit/NSImageView.swift
@@ -58,7 +58,7 @@ public extension ReactiveExtensions where Base: NSImageView {
   }
 }
 
-extension NSImageView: BindableProtocol {
+extension NSImageView {
 
   public func bind(signal: Signal<NSImage?, NoError>) -> Disposable {
     return reactive.image.bind(signal: signal)

--- a/Sources/Bond/AppKit/NSPopUpButton.swift
+++ b/Sources/Bond/AppKit/NSPopUpButton.swift
@@ -62,7 +62,7 @@ public extension ReactiveExtensions where Base: NSPopUpButton {
   }
 }
 
-extension NSPopUpButton: BindableProtocol {
+extension NSPopUpButton {
 
   public func bind(signal: Signal<NSMenuItem?, NoError>) -> Disposable {
     return reactive.selectedItem.bind(signal: signal)

--- a/Sources/Bond/AppKit/NSSegmentedControl.swift
+++ b/Sources/Bond/AppKit/NSSegmentedControl.swift
@@ -57,7 +57,7 @@ public extension ReactiveExtensions where Base: NSSegmentedControl {
   }
 }
 
-extension NSSegmentedControl: BindableProtocol {
+extension NSSegmentedControl {
   
   public func bind(signal: Signal<Int, NoError>) -> Disposable {
     return reactive.selectedSegment.bind(signal: signal)

--- a/Sources/Bond/AppKit/NSSlider.swift
+++ b/Sources/Bond/AppKit/NSSlider.swift
@@ -64,7 +64,7 @@ public extension ReactiveExtensions where Base: NSSlider {
   }
 }
 
-extension NSSlider: BindableProtocol {
+extension NSSlider {
 
   public func bind(signal: Signal<Double, NoError>) -> Disposable {
     return reactive.doubleValue.bind(signal: signal)

--- a/Sources/Bond/AppKit/NSTextField.swift
+++ b/Sources/Bond/AppKit/NSTextField.swift
@@ -110,7 +110,7 @@ public extension ReactiveExtensions where Base: NSTextField {
   }
 }
 
-extension NSTextField: BindableProtocol {
+extension NSTextField {
 
   public func bind(signal: Signal<String, NoError>) -> Disposable {
     return reactive.stringValue.bind(signal: signal)


### PR DESCRIPTION
This PR moves a number of `NSControl` properties from being `Bond<T>` to `DynamicSubject<T>` to more closely match AppKit's handling of control values.