### PR TITLE
Fixes a crash in the new protocol proxy code

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "ReactiveKit/ReactiveKit" "v3.7.1"
+github "ReactiveKit/ReactiveKit" "v3.7.2"
 github "tonyarnold/Differ" "1.0.2"

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/ReactiveKit/ReactiveKit.git",
         "state": {
           "branch": null,
-          "revision": "851ca35cf41bc9a6030b7bb1e7bcdbf9b0e764e3",
-          "version": "3.7.1"
+          "revision": "0fb1cce63f28a79e1d80def394191513f8baf724",
+          "version": "3.7.2"
         }
       }
     ]

--- a/Sources/Bond/ProtocolProxy.swift
+++ b/Sources/Bond/ProtocolProxy.swift
@@ -75,7 +75,7 @@ private extension BNDInvocation {
 
   func write<U, V>(_ value: V, as type: U.Type) {
       let pointer = UnsafeMutablePointer<U>.allocate(capacity: 1)
-      pointer.pointee = value as! U
+      pointer.initialize(to: value as! U, count: 1)
       setReturnValue(pointer)
       pointer.deallocate(capacity: 1)
     }


### PR DESCRIPTION
This PR changes the extensions on `BNDInvocation` to use UnsafeMutablePointer’s `initialize(to: …, count: …)` rather than directly assigning the `pointee` property. 

From Apple's documentation:

> Do not assign an instance of a nontrivial type through pointee to uninitialized memory. Instead, use an initializing method, such as initialize(to:count:).


