### PR TITLE
Fix Swift Package Manager tests

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,12 +3,16 @@ import PackageDescription
 
 let package = Package(
   name: "Bond",
+  products: [
+    .library(name: "Bond", targets: ["Bond"])
+  ],
   dependencies: [
     .package(url: "https://github.com/ReactiveKit/ReactiveKit.git", .upToNextMajor(from: "3.7.0")),
     .package(url: "https://github.com/tonyarnold/Differ.git", .upToNextMajor(from: "1.0.0"))
   ],
   targets: [
     .target(name: "BNDProtocolProxyBase"),
-    .target(name: "Bond", dependencies: ["BNDProtocolProxyBase", "ReactiveKit", "Differ"])
+    .target(name: "Bond", dependencies: ["BNDProtocolProxyBase", "ReactiveKit", "Differ"]),
+    .testTarget(name: "BondTests", dependencies: ["Bond"])
   ]
 )

--- a/Tests/BondTests/ProtocolProxyTests.swift
+++ b/Tests/BondTests/ProtocolProxyTests.swift
@@ -6,6 +6,12 @@
 //  Copyright © 2016 Swift Bond. All rights reserved.
 //
 
+#if os(macOS)
+import AppKit
+#else
+import UIKit
+#endif
+
 import XCTest
 import ReactiveKit
 @testable import Bond
@@ -143,7 +149,7 @@ class ProtocolProxyTests: XCTestCase {
       subject.next(value)
     }
 
-    signal.expectNext([IndexPath(row: 2, section: 2), IndexPath(row: 3, section: 3)])
+    signal.expectNext([IndexPath(indexes: [2, 2]), IndexPath(indexes: [3, 3])])
     object.callMethodE(NSIndexPath(row: 2, section: 2))
     object.callMethodE(NSIndexPath(row: 3, section: 3))
   }
@@ -154,8 +160,18 @@ class ProtocolProxyTests: XCTestCase {
       return 5
     }
 
-    signal.expectNext([IndexPath(row: 2, section: 2), IndexPath(row: 3, section: 3)])
+    signal.expectNext([IndexPath(indexes: [2, 2]), IndexPath(indexes: [3, 3])])
     object.callMethodF(NSIndexPath(row: 2, section: 2))
     object.callMethodF(NSIndexPath(row: 3, section: 3))
   }
 }
+
+#if os(macOS)
+  private extension NSIndexPath {
+    // AppKit lacks the following convenience - on mac OS 10.11 and later, it is `init(forRow: Int, inSection: Int)`
+    convenience init(row: Int, section: Int) {
+      self.init(index: section)
+      adding(row)
+    }
+  }
+#endif


### PR DESCRIPTION
In concert with the changes in https://github.com/ReactiveKit/ReactiveKit/pull/169, this will fix the failing Swift PM tests.