### PR TITLE
Bump ReactiveKit to v3.7.3

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "ReactiveKit/ReactiveKit" "v3.7.2"
+github "ReactiveKit/ReactiveKit" "v3.7.3"
 github "tonyarnold/Differ" "1.0.2"

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/ReactiveKit/ReactiveKit.git",
         "state": {
           "branch": null,
-          "revision": "0fb1cce63f28a79e1d80def394191513f8baf724",
-          "version": "3.7.2"
+          "revision": "6ee182d81a6e03fb23b177123f5787afc2a7960e",
+          "version": "3.7.3"
         }
       }
     ]

--- a/Tests/BondTests/ProtocolProxyTests.swift
+++ b/Tests/BondTests/ProtocolProxyTests.swift
@@ -150,8 +150,8 @@ class ProtocolProxyTests: XCTestCase {
     }
 
     signal.expectNext([IndexPath(indexes: [2, 2]), IndexPath(indexes: [3, 3])])
-    object.callMethodE(NSIndexPath(row: 2, section: 2))
-    object.callMethodE(NSIndexPath(row: 3, section: 3))
+    object.callMethodE(NSIndexPath(indexes: [2, 2], length: 2))
+    object.callMethodE(NSIndexPath(indexes: [3, 3], length: 2))
   }
 
   func testCallbackF() {
@@ -161,17 +161,7 @@ class ProtocolProxyTests: XCTestCase {
     }
 
     signal.expectNext([IndexPath(indexes: [2, 2]), IndexPath(indexes: [3, 3])])
-    object.callMethodF(NSIndexPath(row: 2, section: 2))
-    object.callMethodF(NSIndexPath(row: 3, section: 3))
+    _ = object.callMethodF(NSIndexPath(indexes: [2, 2], length: 2))
+    _ = object.callMethodF(NSIndexPath(indexes: [3, 3], length: 2))
   }
 }
-
-#if os(macOS)
-  private extension NSIndexPath {
-    // AppKit lacks the following convenience - on mac OS 10.11 and later, it is `init(forRow: Int, inSection: Int)`
-    convenience init(row: Int, section: Int) {
-      self.init(index: section)
-      adding(row)
-    }
-  }
-#endif


### PR DESCRIPTION
I think we might need a procedure doc or something so that we get these versions updated in the right order. SwiftPM should cope if we remove `Package.resolved` from the repo, but the checked in Carthage submodules are still going to need bumping. 

Eh, this'll get us back to green lights for now.