### PR TITLE
Fix for CStructs in ProtocolProxy

### DIFF
--- a/Sources/Bond/ProtocolProxy.swift
+++ b/Sources/Bond/ProtocolProxy.swift
@@ -71,6 +71,8 @@ private extension BNDInvocation {
       return pointer.assumingMemoryBound(to: Optional<Selector>.self).pointee as! T
     case NSObjCObjectType:
       return pointer.assumingMemoryBound(to: Optional<AnyObject>.self).pointee as! T
+    case NSObjCStructType:
+      return pointer.assumingMemoryBound(to: T.self).pointee
     default:
       fatalError("Bridging ObjC type `\(type)` is not supported.")
     }


### PR DESCRIPTION
This is a possible fix for issue #481 
In case of a CStruct we just return the same type without bridging it.
This should solve issues with CGPoint, CGRect, NSRange, etc